### PR TITLE
Allow Environment variable to switch Mythril API host, e.g. to staging

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const requester = require('./lib/requester')
 const simpleRequester = require('./lib/simpleRequester')
 const poller = require('./lib/poller')
 
-const defaultApiUrl = 'https://api.mythril.ai'
+const defaultApiUrl = process.env['MYTHRIL_API_URL'] || 'https://api.mythril.ai'
 const defaultApiVersion = 'v1'
 
 class Client {


### PR DESCRIPTION
I've been working around the inabilithy to set the API host on the backend.

If we can get this out, this simple change would simpily things a bit for me.

(This was part of the other stalled, PR. Since this is important I am splitting it off. The other PR needs to be rebased off of master anyway.)