### PR TITLE
Fix analyze example; increase default timeout

### DIFF
--- a/example/analysis
+++ b/example/analysis
@@ -4,7 +4,7 @@
 const fs = require('fs')
 
 function usage() {
-    console.log(`usage: ${process.argv[1]} [*mythril-api-json-path*]
+    console.log(`usage: ${process.argv[1]} [*mythril-api-json-path*] [*timeout-secs*]
 
 Run the Mythril Platform API analysis on *mythril-api-json-path*
 
@@ -15,10 +15,18 @@ Set environment variables EMAIL and MYTHRIL_API_KEY before using.
 
 require('./helper')
 
-if (process.argv.length === 3 &&
+const argLen = process.argv.length
+if (argLen === 3 &&
     process.argv[2].match(/^[-]{0,2}h(?:elp)?$/)) {
     usage()
 }
+
+let timeout = 20
+if (argLen >= 3 &&
+    process.argv[argLen-1].match(/^\d+$/)) {
+    timeout = parseInt(process.argv[argLen-1])
+}
+
 
 const jsonPath = process.argv[2] || `${__dirname}/sample-json/PublicArray.json`
 
@@ -29,7 +37,6 @@ const jsonPath = process.argv[2] || `${__dirname}/sample-json/PublicArray.json`
 const options = {
     apiKey: process.env.MYTHRIL_API_KEY,
     userEmail: process.env.EMAIL,
-    data: JSON.parse(fs.readFileSync(jsonPath, 'utf8')),
     platforms: []  // client chargeback
 }
 
@@ -38,7 +45,12 @@ const armlet = require('../index') // if not installed
 
 const client = new armlet.Client(options)
 
-client.analyze(options)
+const analyzeOptions = {
+    data: JSON.parse(fs.readFileSync(jsonPath, 'utf8')),
+    timeout: timeout * 1000  // convert secs to millisecs
+}
+
+client.analyze(analyzeOptions)
     .then(issues => {
         console.log(issues)
     }).catch(err => {

--- a/lib/poller.js
+++ b/lib/poller.js
@@ -1,4 +1,4 @@
-exports.do = (uuid, apiKey, apiUrl, pollStep = 1000, timeout = 10000) => {
+exports.do = (uuid, apiKey, apiUrl, pollStep = 1000, timeout = 30000) => {
   let pollIntervalID = null
   let timeoutID = null
 


### PR DESCRIPTION
example/analysis:
  * track interface change: split analysis options from client options
  * allow a timeout parameter (in seconds)
lib/poller:
  * up default timeout to 30 seconds