### PR TITLE
Fix bug in compatibility in using old API.

### DIFF
--- a/example/analysis
+++ b/example/analysis
@@ -8,7 +8,12 @@ function usage() {
 
 Run  MythOS analyses on *mythril-api-json-path*
 
-Set environment MYTHRIL_PASSWORD and MYTHRIL_ETH_ADDRESS before using.
+Set environment MYTHRIL_PASSWORD and one of the following:
+
+* MYTHRIL_ETH_ADDRESS or
+* MYTHRIL_EMAIL_ADDRESS
+
+before using.
 `)
     process.exit(1)
 }
@@ -35,15 +40,17 @@ const jsonPath = process.argv[2] || `${__dirname}/sample-json/PublicArray.json`
 ***********************************/
 
 let armletOptions = {
-    // ethAddress: process.env.MYTHRIL_ETH_ADDRESS,
+    apiKey: process.env.MYTHRIL_API_KEY,
+    email: process.env.MYTHRIL_EMAIL,
+    ethAddress: process.env.MYTHRIL_ETH_ADDRESS,
     password: process.env.MYTHRIL_PASSWORD,
     platforms: []  // client chargeback
 }
 
 if (process.env.MYTHRIL_ETH_ADDRESS) {
     armletOptions.ethAddress = process.env.MYTHRIL_ETH_ADDRESS
-} else if (process.env.EMAIL) {
-    armletOptions.email = process.env.EMAIL
+} else if (process.env.MYTHRIL_EMAIL) {
+    armletOptions.email = process.env.MYTHRIL_EMAIL
 }
 
 const armlet = require('../index') // if not installed

--- a/example/analysis
+++ b/example/analysis
@@ -14,6 +14,10 @@ Set environment MYTHRIL_PASSWORD and one of the following:
 * MYTHRIL_EMAIL_ADDRESS
 
 before using.
+
+OR
+
+Set environment MYTHRIL_API_KEY
 `)
     process.exit(1)
 }

--- a/example/helper.js
+++ b/example/helper.js
@@ -1,8 +1,10 @@
-if (!process.env.MYTHRIL_ETH_ADDRESS) {
-  console.log('Please set environment variable MYTHRIL_ETH_ADDRESS.')
+if (!process.env.MYTHRIL_ETH_ADDRESS && !process.env.MYTHRIL_EMAIL) {
+  console.log('Please set either environment variable MYTHRIL_ETH_ADDRESS ' +
+              'or MYTHRIL_EMAIL')
   process.exit(2)
 }
-if (!process.env.MYTHRIL_PASSWORD) {
-  console.log('Please set environment variable MYTHRIL_PASSWORD.')
+
+if (!process.env.MYTHRIL_PASSWORD && !process.env.MYTHRIL_API_KEY) {
+  console.log('Please set environment variable MYTHRIL_PASSWORD or MYTHRIL_API_KEY')
   process.exit(3)
 }

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ class Client {
       throw new TypeError('Please provide an user id auth option.')
     }
 
-    if ((auth.email === undefined || auth.ethAddress !== undefined) && auth.password === undefined) {
+    if (auth.apiKey === undefined && (auth.password === undefined && (auth.email !== undefined || auth.ethAddress !== undefined))) {
       throw new TypeError('Please provide a password auth option.')
     }
 

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ class Client {
       throw new TypeError('Please provide a password auth option.')
     }
 
-    const apiUrl = url.parse(inputApiUrl)
+    const apiUrl = new url.URL(inputApiUrl)
     if (!apiUrl.hostname) {
       throw new TypeError(`${inputApiUrl} is not a valid URL`)
     }

--- a/index.js
+++ b/index.js
@@ -11,27 +11,29 @@ const defaultApiVersion = 'v1'
 
 class Client {
   constructor (auth, inputApiUrl = defaultApiUrl) {
-    if (auth === undefined) {
+    if (typeof auth !== 'object' || Array.isArray(auth)) {
       throw new TypeError('Please provide auth options.')
     }
 
-    if (auth.email === undefined && auth.ethAddress === undefined && auth.apiKey === undefined) {
+    const { email, ethAddress, apiKey, password } = auth
+
+    if (!email && !ethAddress && !apiKey) {
       throw new TypeError('Please provide an user id auth option.')
     }
 
-    if (auth.apiKey === undefined && (auth.password === undefined && (auth.email !== undefined || auth.ethAddress !== undefined))) {
+    if (!apiKey && (!password && (email || ethAddress))) {
       throw new TypeError('Please provide a password auth option.')
     }
 
     const apiUrl = url.parse(inputApiUrl)
-    if (apiUrl.hostname === null) {
+    if (!apiUrl.hostname) {
       throw new TypeError(`${inputApiUrl} is not a valid URL`)
     }
 
-    this.email = auth.email
-    this.ethAddress = auth.ethAddress
-    this.password = auth.password
-    this.accessToken = auth.apiKey
+    this.email = email
+    this.ethAddress = ethAddress
+    this.password = password
+    this.accessToken = apiKey
     this.apiUrl = apiUrl
   }
 

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ const defaultApiVersion = 'v1'
 
 class Client {
   constructor (auth, inputApiUrl = defaultApiUrl) {
-    if (typeof auth !== 'object' || Array.isArray(auth)) {
+    if (!auth) {
       throw new TypeError('Please provide auth options.')
     }
 

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ class Client {
       throw new TypeError('Please provide an user id auth option.')
     }
 
-    if ((auth.email !== undefined || auth.ethAddress !== undefined) && auth.password === undefined) {
+    if ((auth.email === undefined || auth.ethAddress !== undefined) && auth.password === undefined) {
       throw new TypeError('Please provide a password auth option.')
     }
 


### PR DESCRIPTION
Given the _threat_ of a demo and the fact that over the weekend we saw that people are still using the old API_KEY, and the desire to be able to get people up to speed quickly (on prod), I see the wisdom of better compatibility with the old API_KEY. For now. 

The meat of this PR is really in one little logic bug in `index.js`. 

