### PR TITLE
more complete access to API

### DIFF
--- a/example/analysis-issues
+++ b/example/analysis-issues
@@ -54,12 +54,6 @@ let armletOptions = {
     platforms: ['armlet-example']  // client chargeback
 }
 
-if (process.env.MYTHX_ETH_ADDRESS) {
-    armletOptions.ethAddress = process.env.MYTHX_ETH_ADDRESS
-} else if (process.env.MYTHX_EMAIL) {
-    armletOptions.email = process.env.MYTHX_EMAIL
-}
-
 /**********************************
   Example code starts here ...
 ***********************************/

--- a/example/analysis-issues
+++ b/example/analysis-issues
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
-
 "use strict"
 const fs = require('fs')
 
 function usage() {
-    console.log(`usage: ${process.argv[1]} [*mythx-api-json-path*] [*timeout-secs*]
+    console.log(`usage: ${process.argv[1]} *UUID*
 
-Run MythX analyses on *mythx-api-json-path*
+Get MythX status on a previously-submitted analyses. *UUID* is the
+value that was given back by the previously-submitted requiest.
 
 Set environment MYTHX_PASSWORD and one of the following:
 
@@ -35,13 +35,12 @@ if (argLen === 3 &&
 }
 
 let timeout = 20
-if (argLen >= 3 &&
-    process.argv[argLen-1].match(/^\d+$/)) {
-    timeout = parseInt(process.argv[argLen-1])
+if (argLen < 3 || !process.argv[2].match(/^[0-9a-f-]+$/)) {
+    console.log("Need to pass a UUID...\n")
+    usage()
 }
 
-
-const jsonPath = process.argv[2] || `${__dirname}/sample-json/PublicArray.json`
+const uuid = process.argv[2]
 
 /**********************************
   Authentication and option setup
@@ -70,12 +69,7 @@ const armlet = require('../index') // if not installed
 
 const client = new armlet.Client(armletOptions)
 
-const analyzeOptions = {
-    data: JSON.parse(fs.readFileSync(jsonPath, 'utf8')),
-    timeout: timeout * 1000  // convert secs to millisecs
-}
-
-client.analyzeWithStatus(analyzeOptions)
+client.analyzeIssues(uuid)
     .then(issues => {
         const util = require('util')
         console.log(`${util.inspect(issues, {depth: null})}`)

--- a/example/analysis-status
+++ b/example/analysis-status
@@ -54,12 +54,6 @@ let armletOptions = {
     platforms: ['armlet-example']  // client chargeback
 }
 
-if (process.env.MYTHX_ETH_ADDRESS) {
-    armletOptions.ethAddress = process.env.MYTHX_ETH_ADDRESS
-} else if (process.env.MYTHX_EMAIL) {
-    armletOptions.email = process.env.MYTHX_EMAIL
-}
-
 /**********************************
   Example code starts here ...
 ***********************************/

--- a/example/analysis-status
+++ b/example/analysis-status
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
-
 "use strict"
 const fs = require('fs')
 
 function usage() {
-    console.log(`usage: ${process.argv[1]} [*mythx-api-json-path*] [*timeout-secs*]
+    console.log(`usage: ${process.argv[1]} *UUID*
 
-Run MythX analyses on *mythx-api-json-path*
+Get MythX status on a previously-submitted analyses. *UUID* is the
+value that was given back by the previously-submitted requiest.
 
 Set environment MYTHX_PASSWORD and one of the following:
 
@@ -35,13 +35,12 @@ if (argLen === 3 &&
 }
 
 let timeout = 20
-if (argLen >= 3 &&
-    process.argv[argLen-1].match(/^\d+$/)) {
-    timeout = parseInt(process.argv[argLen-1])
+if (argLen < 3 || !process.argv[2].match(/^[0-9a-f-]+$/)) {
+    console.log("Need to pass a UUID...\n")
+    usage()
 }
 
-
-const jsonPath = process.argv[2] || `${__dirname}/sample-json/PublicArray.json`
+const uuid = process.argv[2]
 
 /**********************************
   Authentication and option setup
@@ -70,12 +69,7 @@ const armlet = require('../index') // if not installed
 
 const client = new armlet.Client(armletOptions)
 
-const analyzeOptions = {
-    data: JSON.parse(fs.readFileSync(jsonPath, 'utf8')),
-    timeout: timeout * 1000  // convert secs to millisecs
-}
-
-client.analyzeWithStatus(analyzeOptions)
+client.analyzeStatus(uuid)
     .then(issues => {
         const util = require('util')
         console.log(`${util.inspect(issues, {depth: null})}`)

--- a/index.js
+++ b/index.js
@@ -175,13 +175,12 @@ class Client {
   }
 
   async getIssues (uuid, inputApiUrl = defaultApiUrl) {
-    let accessToken = this.accessToken
-    if (!accessToken) {
+    if (!this.accessToken) {
       const tokens = await login.do(this.email, this.ethAddress, this.password, this.apiUrl)
-      accessToken = tokens.access
+      this.accessToken = tokens.access
     }
     const url = `${inputApiUrl}/${defaultApiVersion}/analyses/${uuid}/issues`
-    return simpleRequester.do({ url, accessToken: accessToken, json: true })
+    return simpleRequester.do({ url, accessToken: this.accessToken, json: true })
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ class Client {
     *
     * @returns an array-like object of issues, and a uuid attribute which can
     *          be subsequently used to retrieve the information from our stored
-    *          database using analyzeIssues().
+    *          database using getIssues().
     *
     **/
   async analyze (options) {
@@ -157,14 +157,14 @@ class Client {
     const issues = await this.analyze(options)
     const uuid = issues.uuid
     delete issues.uuid
-    const status = await this.analyzeStatus(uuid)
+    const status = await this.getStatus(uuid)
     return {
       issues,
       status
     }
   }
 
-  async analyzeStatus (uuid, inputApiUrl = defaultApiUrl) {
+  async getStatus (uuid, inputApiUrl = defaultApiUrl) {
     let accessToken = this.accessToken
     if (!accessToken) {
       const tokens = await login.do(this.email, this.ethAddress, this.password, this.apiUrl)
@@ -174,7 +174,7 @@ class Client {
     return simpleRequester.do({ url, accessToken: accessToken, json: true })
   }
 
-  async analyzeIssues (uuid, inputApiUrl = defaultApiUrl) {
+  async getIssues (uuid, inputApiUrl = defaultApiUrl) {
     let accessToken = this.accessToken
     if (!accessToken) {
       const tokens = await login.do(this.email, this.ethAddress, this.password, this.apiUrl)

--- a/index.js
+++ b/index.js
@@ -10,6 +10,18 @@ const defaultApiUrl = process.env['MYTHX_API_URL'] || 'https://api.mythx.io'
 const defaultApiVersion = 'v1'
 
 class Client {
+  /**
+   *  Creates a client object. Internally this has login information, and from that
+   *  an access token. By saving state, we can use and refresh the access token
+   *  periodically.
+   *
+   *  @param {auth} object         - login or authentication information which contains
+   *                               (email | ethAddress) and a password or...
+   *                                apiKey
+   *  @param {inputApiUrl} string  - Optional. A URL of a MythX API server we want to contect
+   *                                 to.
+   *
+   */
   constructor (auth, inputApiUrl = defaultApiUrl) {
     if (!auth) {
       throw new TypeError('Please provide auth options.')
@@ -37,6 +49,19 @@ class Client {
     this.apiUrl = apiUrl
   }
 
+  /**
+    * Runs MythX analysis.
+    * Deprecated. See analyzeWithStatus() instead.
+    *
+    * @param {options} object - structure which must contain
+    *      {data} object       - information containing Smart Contract information to be analyzed
+    *      {timeout} number    - optional timeout value in milliseconds
+    *
+    * @returns an array-like object of issues, and a uuid attribute which can
+    *          be subsequently used to retrieve the information from our stored
+    *          database using analyzeIssues().
+    *
+    **/
   async analyze (options) {
     if (options === undefined || options.data === undefined || options.data.deployedBytecode === undefined) {
       throw new TypeError('Please provide a deployedBytecode option.')
@@ -75,9 +100,20 @@ class Client {
 
       result = await poller.do(uuid, this.accessToken, this.apiUrl, undefined, options.timeout)
     }
+    result.uuid = uuid
     return result
   }
 
+  /**
+    * Retrieves status records of past MythX analyses requests.
+    *
+    * @param {options} object - structure which must contain
+    *      {data} object       - information containing Smart Contract information to be analyzed
+    *      {timeout} number    - optional timeout value in milliseconds
+    *
+    * @returns an array-like object of issue status from our stored database.
+    *
+    **/
   async analyses (options) {
     if (options === undefined || options.dateFrom === undefined) {
       throw new TypeError('Please provide a dateFrom option.')
@@ -103,6 +139,49 @@ class Client {
       analyses = await simpleRequester.do({ url, accessToken: this.accessToken, json: true })
     }
     return analyses
+  }
+
+  /**
+    * Runs MythX analysis return issue information and metadata regarding the run
+    *
+    * @param {options} object - structure which must contain:
+    *      {data} object       - information containing Smart Contract information to be analyzed
+    *      {timeout} number    - optional timeout value in milliseconds
+    *
+    * @returns object which contains:
+    *      (issues}  object - an like object which of issues is grouped by (file) input container.
+    *      {status}  object - status information as returned in each object of analyses().
+    *
+    **/
+  async analyzeWithStatus (options) {
+    const issues = await this.analyze(options)
+    const uuid = issues.uuid
+    delete issues.uuid
+    const status = await this.analyzeStatus(uuid)
+    return {
+      issues,
+      status
+    }
+  }
+
+  async analyzeStatus (uuid, inputApiUrl = defaultApiUrl) {
+    let accessToken = this.accessToken
+    if (!accessToken) {
+      const tokens = await login.do(this.email, this.ethAddress, this.password, this.apiUrl)
+      accessToken = tokens.access
+    }
+    const url = `${inputApiUrl}/${defaultApiVersion}/analyses/${uuid}`
+    return simpleRequester.do({ url, accessToken: accessToken, json: true })
+  }
+
+  async analyzeIssues (uuid, inputApiUrl = defaultApiUrl) {
+    let accessToken = this.accessToken
+    if (!accessToken) {
+      const tokens = await login.do(this.email, this.ethAddress, this.password, this.apiUrl)
+      accessToken = tokens.access
+    }
+    const url = `${inputApiUrl}/${defaultApiVersion}/analyses/${uuid}/issues`
+    return simpleRequester.do({ url, accessToken: accessToken, json: true })
   }
 }
 

--- a/lib/simpleRequester.js
+++ b/lib/simpleRequester.js
@@ -14,7 +14,18 @@ exports.do = options => {
         reject(error)
         return
       }
-      if (res.statusCode !== 200) {
+      if (res.statusCode === 401) {
+        const prefix = 'HTTP status 401: '
+        try {
+          body = JSON.parse(body)
+          reject(new Error(`${prefix}${body.error}`))
+        } catch (err) {
+          reject(new Error(`${prefix}${err}`))
+          return
+        }
+        reject(HttpErrors(res.statusCode, body.error))
+        return
+      } else if (res.statusCode !== 200) {
         reject(HttpErrors(res.statusCode, 'Invalid status code, expected 200'))
         return
       }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "armlet",
-  "version": "1.0.0",
-  "description": "A Mythril Platform API client.",
+  "version": "1.1.0",
+  "description": "A MythX API client.",
   "main": "index.js",
   "scripts": {
     "lint": "eslint .",


### PR DESCRIPTION
* add analyzeWithStatus() - runs deprecated analyze() and melds with analyzeStatus() in result
* add getStatus() - gets status by UUID
* add getIssues() - gets issue information from past runs
* example/analysis-status - use of above
* lib/simpleRequester.js: better status on HTTP 401 results

Start documenting function parameter and return values