### PR TITLE
[BAH-63] do not require deployed bytecode

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,8 +38,8 @@ class Client {
   }
 
   async analyze (options) {
-    if (options === undefined || options.data === undefined || options.data.deployedBytecode === undefined) {
-      throw new TypeError('Please provide a deployedBytecode option.')
+    if (options === undefined || options.data === undefined) {
+      throw new TypeError('Please provide a data option.')
     }
 
     if (!this.accessToken) {

--- a/test/index.js
+++ b/test/index.js
@@ -95,8 +95,8 @@ describe('main module', () => {
                 this.instance.analyze.should.be.a('function')
               })
 
-              it('should require a deployedBytecode option', async () => {
-                await this.instance.analyze().should.be.rejectedWith(TypeError)
+              it('should require a data option', async () => {
+                await this.instance.analyze({ 'field': 'value' }).should.be.rejectedWith(TypeError)
               })
             })
             describe('have an analyses method which', () => {


### PR DESCRIPTION
After recent changes, none of the tools use deployed bytecode (we changed mythril to use creation bytecode). 

Also, as part of BAH-63 we are relaxing the requirements on the input fields for the analysis request, and during the beta test it will be possible to send just `{bytecode: 0x...}`. 

So we need to remove the check for non-empty `deployedBytecode`.