### PR TITLE
On redirect on http login, turn into https login

### DIFF
--- a/lib/login.js
+++ b/lib/login.js
@@ -13,6 +13,17 @@ exports.do = (email, ethAddress, userId, password, apiUrl) => {
         return
       }
 
+      // Handle redirect
+      if (res.statusCode === 308 && apiUrl.protocol === 'http:') {
+        apiUrl.protocol = 'https:'
+        this.do(email, ethAddress, password, apiUrl).then(result => {
+          resolve(result)
+        }).catch(error => {
+          reject(error)
+        })
+        return
+      }
+
       if (res.statusCode !== 200) {
         reject(new Error(`Invalid status code ${res.statusCode}, ${body}`))
         return

--- a/test/lib/login.js
+++ b/test/lib/login.js
@@ -28,6 +28,16 @@ describe('login', () => {
       await login.do(email, ethAddress, userId, password, parsedApiUrl).should.eventually.deep.equal(jsonTokens)
     })
 
+    it('should redirect refresh and access tokens', async () => {
+      nock('http://localhost:3100')
+        .post(loginPath, auth)
+        .reply(200, jsonTokens)
+
+      const parsedApiUrlHttp = new url.URL('http://localhost:3100')
+      await login.do(email, ethAddress, userId, password, parsedApiUrlHttp)
+        .should.eventually.deep.equal(jsonTokens)
+    })
+
     it('should reject on api server connection failure', async () => {
       const invalidUrlObject = 'not-an-url-object'
 


### PR DESCRIPTION
@fgimenez mentioned having a problem in the code the last time I suggested converting http:// to https:// because you run locally which allows the http protocol.

Here we only do a http->https redirect _only_ on a HTTP 308 response which in your situation won't occur. 

If this is acceptable, let me know. This is a nice to have but not as user-friendly necessary as some of the other HTTP response code handling I feel are.

