### PR TITLE
[Improvemnts]change http-client from http(s) to request for proxy environment in p…

### DIFF
--- a/lib/poller.js
+++ b/lib/poller.js
@@ -1,6 +1,7 @@
 const HttpErrors = require('http-errors')
 const moment = require('moment')
 const humanizeDuration = require('humanize-duration')
+const request = require('request')
 
 exports.do = (uuid, accessToken, apiUrl, pollStep = 1000, timeout = 30000) => {
   let pollIntervalID = null
@@ -24,20 +25,21 @@ exports.do = (uuid, accessToken, apiUrl, pollStep = 1000, timeout = 30000) => {
   })
 
   const pollPromise = new Promise((resolve, reject) => {
-    const lib = apiUrl.protocol === 'http:' ? require('http') : require('https')
-    const getOptions = {
-      protocol: apiUrl.protocol,
-      hostname: apiUrl.hostname,
-      port: apiUrl.port,
-      path: `/v1/analyses/${uuid}/issues`,
+    const options = {
+      url: `${apiUrl.href}v1/analyses/${uuid}/issues`,
       headers: {
         'Authorization': `Bearer ${accessToken}`
       }
     }
     const getFunc = () => {
-      lib.get(
-        getOptions,
-        res => {
+      request.get(
+        options,
+        (err, res, body) => {
+          const errMsg = `Failed in retrieving issues response, HTTP status code: ${res.statusCode}\n${res.statusMessage}`
+          if (err) {
+            clearActions()
+            reject(errMsg)
+          }
           if (res.statusCode === 401) {
             clearActions()
             reject(HttpErrors(401, `Unauthorized analysis request, access token: ${accessToken}`))
@@ -47,26 +49,22 @@ exports.do = (uuid, accessToken, apiUrl, pollStep = 1000, timeout = 30000) => {
             reject(HttpErrors(500, 'received error 500 from API server'))
           }
 
-          let rawData = ''
-          res.on('data', chunk => { rawData += chunk })
-          res.on('end', () => {
-            let data = {}
-            try {
-              if (rawData !== '') {
-                // Data can be the empty string on MythX internal
-                // error. The caller will pick out the exact error from the
-                // status
-                data = JSON.parse(rawData)
-              }
-            } catch (err) {
-              clearActions()
-              reject(err)
+          let data = {}
+          try {
+            if (body !== '') {
+              // Data can be the empty string on MythX internal
+              // error. The caller will pick out the exact error from the
+              // status
+              data = JSON.parse(body)
             }
-            if (res.statusCode === 200) {
-              clearActions()
-              resolve(data)
-            }
-          })
+          } catch (err) {
+            clearActions()
+            reject(err)
+          }
+          if (res.statusCode === 200) {
+            clearActions()
+            resolve(data)
+          }
         }
       )
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "armlet",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "A MythX API client.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Armlet usually uses `request` package as http-client.
However, somehow `http(s)` package is used in poller.js
This may make users in environment with proxy difficult to use armlet.
I changed http-client in poller.js from `http(s)` to `request`.
Could you check my PR and merge it?
