### PR TITLE
[bug fix] timeout of analysisMode is never used and the logic looks w…

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,9 +117,11 @@ minimum value for how long a non-cached analyses will take
     */
     let timeout = options.timeout
     if (!('timeout' in options)) {
-      options.timeout = (60 * 1000) * (options.data.analysisMode === 'full')
-        ? 5 // 5 minutes
-        : (5 * 60) // 5 hours
+      timeout = (60 * 1000) * (
+        (options.data.analysisMode !== 'full')
+          ? 5 // 5 minutes
+          : (5 * 60) // 5 hours
+      )
     }
 
     if (options.debug) {

--- a/lib/analysisPoller.js
+++ b/lib/analysisPoller.js
@@ -145,7 +145,7 @@ exports.inverseFn = function (timeout) {
  * @param {String} accessToken Auth token.
  * @param {Object} apiUrl URL object of API base (without /v1, though).
  * @param {Number} timeout Optional. Operation timeout [ms]. Defaults to 30 sec.
- * @param {Number} initialTimeout Optional. Operation timeout [ms]. Defaults to 30 sec.
+ * @param {Number} initialDelay Optional. Operation timeout [ms]. Defaults to 30 sec.
  *  (For initial polling only)
  * @return {Promise} Resolves to the list of issues, or rejects with an error.
  */


### PR DESCRIPTION
Looks like that timeout based on  `analysisMode` is never used and the login is wrong.
Do you check whether this is the logic you assumed originally?

And comment for `initialDelay` looks wrong.