### PR TITLE
fix JWT token refresh

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,7 +91,7 @@ minimum value for how long a non-cached analyses will take
     try {
       requestResponse = await requester.do(options, this.accessToken, this.apiUrl)
     } catch (e) {
-      if (e.statusCode !== 401) {
+      if (e.status !== 401) {
         throw e
       }
       const tokens = await refresh.do(this.accessToken, this.refreshToken, this.apiUrl)
@@ -183,7 +183,7 @@ minimum value for how long a non-cached analyses will take
     try {
       analyses = await simpleRequester.do({ url, accessToken: this.accessToken, json: true })
     } catch (e) {
-      if (e.statusCode !== 401) {
+      if (e.status !== 401) {
         throw e
       }
       const tokens = await refresh.do(this.accessToken, this.refreshToken, this.apiUrl)

--- a/index.js
+++ b/index.js
@@ -141,7 +141,7 @@ minimum value for how long a non-cached analyses will take
       try {
         result = await analysisPoller.do(requestResponse.uuid, this.accessToken, this.apiUrl, timeout, initialDelay, options.debug)
       } catch (e) {
-        if (e.statusCode !== 401) {
+        if (e.status !== 401) {
           throw e
         }
         const tokens = await refresh.do(this.accessToken, this.refreshToken, this.apiUrl)

--- a/lib/analysisPoller.js
+++ b/lib/analysisPoller.js
@@ -57,6 +57,9 @@ async function handleErrors (response, accessToken, uuid) {
   if (status < 200 || status > 299) {
     let msg = `Failed in retrieving analysis response, HTTP status code: ${status}. UUID: ${uuid}`
     switch (status) {
+      case 401:
+        msg = response
+        break
       case 404:
         msg = `Unauthorized analysis request, access token: ${accessToken}`
         break

--- a/lib/refresh.js
+++ b/lib/refresh.js
@@ -3,7 +3,7 @@ const util = require('./util')
 
 const basePath = 'v1/auth/refresh'
 
-exports.do = (refreshToken, accessToken, apiUrl) => {
+exports.do = (accessToken, refreshToken, apiUrl) => {
   return new Promise((resolve, reject) => {
     const options = { form: { refreshToken, accessToken } }
     const url = util.joinUrl(apiUrl.href, basePath)
@@ -26,11 +26,11 @@ exports.do = (refreshToken, accessToken, apiUrl) => {
         return
       }
 
-      if (!body.refreshToken) {
+      if (!body.refresh) {
         reject(new Error(`Refresh Token missing`))
       }
 
-      if (!body.accessToken) {
+      if (!body.access) {
         reject(new Error(`Access Token missing`))
       }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "armlet",
-  "version": "2.0.2",
+  "name": " ",
+  "version": "2.0.2-git",
   "description": [
     "Armlet is a thin wrapper around the MythX API written in Javascript.",
     "It simplifies interaction with MythX. For example, the library",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "armlet",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": [
     "Armlet is a thin wrapper around the MythX API written in Javascript.",
     "It simplifies interaction with MythX. For example, the library",

--- a/test/lib/refresh.js
+++ b/test/lib/refresh.js
@@ -14,20 +14,20 @@ describe('refresh', () => {
     const expiredRefreshToken = 'expiredRefresh'
     const expiredAccessToken = 'expiredAccess'
     const expiredJsonTokens = { refreshToken: expiredRefreshToken, accessToken: expiredAccessToken }
-    const renewedJsonTokens = { refreshToken: 'renewedRefresh', accessToken: 'renewedAccess' }
+    const renewedJsonTokens = { refresh: 'renewedRefresh', access: 'renewedAccess' }
 
     it('should return renewed refresh and access tokens', async () => {
       nock(apiUrl)
         .post(refreshPath, expiredJsonTokens)
         .reply(200, renewedJsonTokens)
 
-      await refresh.do(expiredRefreshToken, expiredAccessToken, parsedApiUrl).should.eventually.deep.equal(renewedJsonTokens)
+      await refresh.do(expiredAccessToken, expiredRefreshToken, parsedApiUrl).should.eventually.deep.equal(renewedJsonTokens)
     })
 
     it('should reject on api server connection failure', async () => {
       const invalidApiHostname = 'not-an-url-object'
 
-      await refresh.do(expiredRefreshToken, expiredAccessToken, invalidApiHostname).should.be.rejectedWith(Error)
+      await refresh.do(expiredAccessToken, expiredRefreshToken, invalidApiHostname).should.be.rejectedWith(Error)
     })
 
     it('should reject on api server status code != 200', async () => {
@@ -35,7 +35,7 @@ describe('refresh', () => {
         .post(refreshPath, expiredJsonTokens)
         .reply(500)
 
-      await refresh.do(expiredRefreshToken, expiredAccessToken, parsedApiUrl).should.be.rejectedWith(Error, 'Invalid status code')
+      await refresh.do(expiredAccessToken, expiredRefreshToken, parsedApiUrl).should.be.rejectedWith(Error, 'Invalid status code')
     })
 
     it('should reject on non-JSON data', async () => {
@@ -43,23 +43,23 @@ describe('refresh', () => {
         .post(refreshPath, expiredJsonTokens)
         .reply(200, 'newjsonTextTokens')
 
-      await refresh.do(expiredRefreshToken, expiredAccessToken, parsedApiUrl).should.be.rejectedWith(Error, 'JSON parse error')
+      await refresh.do(expiredAccessToken, expiredRefreshToken, parsedApiUrl).should.be.rejectedWith(Error, 'JSON parse error')
     })
 
     it('should reject if refreshToken is not present in response', async () => {
       nock(apiUrl)
         .post(refreshPath, expiredJsonTokens)
-        .reply(200, { accessToken: 'access' })
+        .reply(200, { access: 'access' })
 
-      await refresh.do(expiredRefreshToken, expiredAccessToken, parsedApiUrl).should.be.rejectedWith(Error, 'Refresh Token missing')
+      await refresh.do(expiredAccessToken, expiredRefreshToken, parsedApiUrl).should.be.rejectedWith(Error, 'Refresh Token missing')
     })
 
     it('should reject if accessToken is not present', async () => {
       nock(apiUrl)
         .post(refreshPath, expiredJsonTokens)
-        .reply(200, { refreshToken: 'refresh' })
+        .reply(200, { refresh: 'refresh' })
 
-      await refresh.do(expiredRefreshToken, expiredAccessToken, parsedApiUrl).should.be.rejectedWith(Error, 'Access Token missing')
+      await refresh.do(expiredAccessToken, expiredRefreshToken, parsedApiUrl).should.be.rejectedWith(Error, 'Access Token missing')
     })
   })
 })


### PR DESCRIPTION
Adapted to the output of `handleErrors` in `analysisPoller`. Also fixed errors to align with the current names of fields in the API.