### PR TITLE
Disable coveralls trigger for forks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
           command: npm test
       - run:
           name: Send coverage report
-          command: npm run coverage
+          command: if [ $CIRCLE_REPOSITORY_URL == "https://github.com/ConsenSys/armlet" ]; then npm run coverage; fi
 
       - save_cache:
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
           command: npm test
       - run:
           name: Send coverage report
-          command: if [ $CIRCLE_REPOSITORY_URL == "https://github.com/ConsenSys/armlet" ]; then npm run coverage; fi
+          command: if [ -z "$CIRCLE_PR_USERNAME" ]; then npm run coverage; fi
 
       - save_cache:
           paths:


### PR DESCRIPTION
Circle CI adds environment variable `CIRCLE_PR_USERNAME` whenever PR is created from forked repo, but doesn't set from main repo's branch.