### PR TITLE
Better error messages for HTTP 401...

### DIFF
--- a/lib/requester.js
+++ b/lib/requester.js
@@ -23,9 +23,28 @@ exports.do = (input, accessToken, apiUrl) => {
 
       /* eslint-disable prefer-promise-reject-errors */
       if (res.statusCode < 200 || res.statusCode > 299) {
-        const errMsg = `Failed in retrieving analysis response: ${res.error} (HTTP status code: ${res.status})`
+        const errMsg = `Failed in retrieving analysis response: ${res.statusMessage} (HTTP status code: ${res.statusCode})`
+        // console.log(errMsg)
         if (res.statusCode === 401) {
-          reject('MythX credentials are incorrect.')
+          /* For now, try to provide better 401 error messages. Right now, all we are ever getting
+             back seems to be "Unauthorized". But Remi reports that somewhere in the back end
+             the other two are set, even if right now they don't get passed through.
+           */
+          switch (res.statusMessage) {
+            case 'Unauthorized':
+              reject('MythX credentials are incorrect.')
+              break
+            case 'Challenge expired':
+              reject('The token for the initial JWT login has expired; use the refresh token to get a longer-expiring access token.')
+              break
+            case 'Invalid challenge':
+              reject('MythX credentials are incorrect.')
+              break
+            default:
+            // The hope is that if the message is not one of the above -- and that will happen sometime in the future --
+            // then we have something useful that can be passed back untouched.
+              reject(res.statusMessage)
+          }
           return
         } else if (res.statusCode === 400) {
           reject(res.body.error)


### PR DESCRIPTION
and a correct a field-name in picking out the status message on non 2xx HTTP repsonses