### PR TITLE
bug fix: initialDelay parameter to determe waiting time for first polling is never used.

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,8 +92,8 @@ minimum value for how long a non-cached analyses will take
        a request before giving up.
 
        Unless a timeout has been explicitly given (and we recommend it should be),
-       we will use a value of 3 minutes for a "quick" analysis and
-       3 hours for a "full" analysis.
+       we will use a value of 5 minutes for a "quick" analysis and
+       5 hours for a "full" analysis.
 
        Note:
          A "quick" analysis usually finishes within 90 seconds after the job starts.

--- a/lib/analysisPoller.js
+++ b/lib/analysisPoller.js
@@ -117,16 +117,17 @@ const maxPolls = 10
 exports.maxPolls = maxPolls
 
 // We use the sequence:
-//    (c*i)**2,  i=1 to maxPolls
+//    (c*i)**2,  i=1 to maxPolls - 1
 // for successive polling delays.
+// Substracting by 1 is consideration for first poll based on initialDelay.
 //
 //  To figure out a value of "c" so that the sum of the sequence adds to "timeout":
 //
-//  timeout = sum (x*i)**2,  i=1 to 10 solve for x
+//  timeout = sum (x*i)**2,  i=1 to 9 solve for x
 //
-//  c = +/- sqrt(timeout) / sqrt(385)
+//  c = +/- sqrt(timeout) / sqrt(285)
 //
-// See https://www.wolframalpha.com/input/?i=n+%3D+sum+(x*i)**2,++i%3D1+to+10+solve+for+x
+// See https://www.wolframalpha.com/input/?i=n+%3D+sum+(x*i)**2,++i%3D1+to+9+solve+for+x
 //
 //  We use the positive root.
 //
@@ -137,7 +138,7 @@ exports.maxPolls = maxPolls
 //    too steeply as well.
 
 exports.inverseFn = function (timeout) {
-  return Math.sqrt(timeout) / Math.sqrt(385)
+  return Math.sqrt(timeout) / Math.sqrt(285)
 }
 
 /**
@@ -147,9 +148,8 @@ exports.inverseFn = function (timeout) {
  * @param {String} uuid Analysis UUID.
  * @param {String} accessToken Auth token.
  * @param {Object} apiUrl URL object of API base (without /v1, though).
- * @param {Number} timeout Optional. Operation timeout [ms]. Defaults to 30 sec.
- * @param {Number} initialDelay Optional. Operation timeout [ms]. Defaults to 30 sec.
- *  (For initial polling only)
+ * @param {Number} timeout Operation timeout [ms].
+ * @param {Number} initialDelay Operation timeout [ms]. (For initial polling only)
  * @return {Promise} Resolves to the list of issues, or rejects with an error.
  */
 exports.do = async function (
@@ -174,18 +174,26 @@ exports.do = async function (
 
   let status = 'unknown'
 
-  for (let i = 1; i <= maxPolls; i++) {
-    // Geek note: an optimizing compiler would use "strength reduction"
-    // to turn the below exponentiation by two into a multiplication,
-    // but I am too lazy and the result wouild be to ugly and confusing
-    // to warrant my using it here.
-    const pollStep = (pollC * i) ** 2
+  for (let i = 0; i <= maxPolls - 1; i++) {
+    // wait until time of initialDelay passes if this is the first polling.
+    if (i === 0) {
+      if (debug) {
+        console.log(`polling interval: ${humanizeDuration(initialDelay)}, previous status: ${status}`)
+      }
+      await util.timer(Math.min(initialDelay, start + timeout - Date.now()))
+    } else {
+      // Geek note: an optimizing compiler would use "strength reduction"
+      // to turn the below exponentiation by two into a multiplication,
+      // but I am too lazy and the result wouild be to ugly and confusing
+      // to warrant my using it here.
+      const pollStep = (pollC * i) ** 2
 
-    if (debug) {
-      console.log(`polling interval: ${humanizeDuration(pollStep)}, previous status: ${status}`)
+      if (debug) {
+        console.log(`polling interval: ${humanizeDuration(pollStep)}, previous status: ${status}`)
+      }
+
+      await util.timer(Math.min(pollStep, start + remainTime - Date.now()))
     }
-
-    await util.timer(Math.min(pollStep, start + remainTime - Date.now()))
 
     let statusResponse
     if (Date.now() - start >= timeout) {

--- a/test/lib/geopol.js
+++ b/test/lib/geopol.js
@@ -11,7 +11,7 @@ describe('geometric poller', () => {
       // console.log(pollC)
       let result = []
       let total = 0
-      for (let i = 1; i <= poller.maxPolls; i++) {
+      for (let i = 1; i <= poller.maxPolls - 1; i++) {
         const next = (pollC * i) ** 2
         total += next
         result.push(next)
@@ -19,7 +19,7 @@ describe('geometric poller', () => {
 
       // console.log(total)
       let lastDelay = result[0]
-      for (let i = 1; i < poller.maxPolls; i++) {
+      for (let i = 1; i < poller.maxPolls - 1; i++) {
         // Could get fancier than <
         assert.isBelow(lastDelay, result[i])
         lastDelay = result[i]


### PR DESCRIPTION
`initialDelay` parameter to determe waiting time for first polling is never used.

This PR is to address the issue discussed on [ConsenSys/truffle-security](https://github.com/ConsenSys/truffle-security/issues/95).
