### PR TITLE
Go over how login and refresh errors are reported.

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,8 +83,7 @@ class Client {
         Normally requester passes back strings. However there is a spcial case for
         HTTP 401 JWT access token has expired and we need to refresh it.
       */
-      // console.log('\n\n\nXXX1\n\n');
-      if (e.hasOwnProperty('statusCode') && e.statusCode !== 401) {
+      if (e.statusCode !== 401) {
         throw e
       }
       const tokens = await refresh.do(this.accessToken, this.refreshToken, this.apiUrl)
@@ -138,8 +137,7 @@ class Client {
           Normally requester passes back strings. However there is a spcial case for
           HTTP 401 JWT access token has expired and we need to refresh it.
         */
-        // console.log('\n\n\nXXX3\n\n');
-        if (e.hasOwnProperty('statusCode') && e.statusCode !== 401) {
+        if (e.status !== 401) {
           throw e
         }
         const tokens = await refresh.do(this.accessToken, this.refreshToken, this.apiUrl)
@@ -181,7 +179,7 @@ class Client {
     try {
       analyses = await simpleRequester.do({ url, accessToken: this.accessToken, json: true })
     } catch (e) {
-      if (e.hasOwnProperty('statusCode') && e.statusCode !== 401) {
+      if (e.status !== 401) {
         throw e
       }
       const tokens = await refresh.do(this.accessToken, this.refreshToken, this.apiUrl)
@@ -229,8 +227,9 @@ class Client {
     try {
       result = await simpleRequester.do({ url, accessToken: accessToken, json: true })
     } catch (e) {
-      let msg = `Failed in retrieving analysis response, HTTP status code: ${e.statusCode}. UUID: ${uuid}`
-      if (e.statusCode === 404) {
+      let msg = `Failed in retrieving analysis response, HTTP status code: ${e.status}. UUID: ${uuid}`
+      console.log('EE-status', e.status)
+      if (e.status === 404) {
         msg = `Analysis with UUID ${uuid} not found.`
       }
       throw msg

--- a/index.js
+++ b/index.js
@@ -53,12 +53,12 @@ class Client {
     *      {timeout} number        - optional timeout value in milliseconds
     *      {clientToolName} string - optional; sets up for client tool usage tracking
     *      {initialDelay} number   - optional; After submitting an analysis and seeing that it is
-                                     not cached, the first status API call will be delayed by this
-                                     number of milliseconds
-
-minimum value for how long a non-cached analyses will take
-    *                              this must be larger than defaultInitialDelay which we believe to be
-    *                              the smallest reasonable value.
+    *                                not cached, the first status API call will be delayed by this
+    *                                number of milliseconds
+    *
+    * The minimum value for how long a non-cached analyses will take
+    * must be larger than defaultInitialDelay which we believe to be
+    * the smallest reasonable value.
     *
     * @returns an array-like object of issues, and a uuid attribute which can
     *          be subsequently used to retrieve the information from our stored
@@ -72,12 +72,19 @@ minimum value for how long a non-cached analyses will take
     }
 
     await this.login()
+    // console.log(`Access token: ${this.accessToken}`);
+    // console.log(`Refresh token: ${this.refreshToken}`);
 
     let requestResponse
     try {
       requestResponse = await requester.do(options, this.accessToken, this.apiUrl)
     } catch (e) {
-      if (e.status !== 401) {
+      /*
+        Normally requester passes back strings. However there is a spcial case for
+        HTTP 401 JWT access token has expired and we need to refresh it.
+      */
+      // console.log('\n\n\nXXX1\n\n');
+      if (e.hasOwnProperty('statusCode') && e.statusCode !== 401) {
         throw e
       }
       const tokens = await refresh.do(this.accessToken, this.refreshToken, this.apiUrl)
@@ -127,7 +134,12 @@ minimum value for how long a non-cached analyses will take
       try {
         result = await analysisPoller.do(requestResponse.uuid, this.accessToken, this.apiUrl, timeout, initialDelay, options.debug)
       } catch (e) {
-        if (e.status !== 401) {
+        /*
+          Normally requester passes back strings. However there is a spcial case for
+          HTTP 401 JWT access token has expired and we need to refresh it.
+        */
+        // console.log('\n\n\nXXX3\n\n');
+        if (e.hasOwnProperty('statusCode') && e.statusCode !== 401) {
           throw e
         }
         const tokens = await refresh.do(this.accessToken, this.refreshToken, this.apiUrl)
@@ -169,7 +181,7 @@ minimum value for how long a non-cached analyses will take
     try {
       analyses = await simpleRequester.do({ url, accessToken: this.accessToken, json: true })
     } catch (e) {
-      if (e.status !== 401) {
+      if (e.hasOwnProperty('statusCode') && e.statusCode !== 401) {
         throw e
       }
       const tokens = await refresh.do(this.accessToken, this.refreshToken, this.apiUrl)
@@ -227,7 +239,9 @@ minimum value for how long a non-cached analyses will take
   }
 
   /**
-   * Runs MythX auth/login.
+   * Runs MythX JWT login. On succes sets:
+   *    this.accessToken and this.refreshToken on successu
+   * On failure we throw a a string error message.
    **/
   async login () {
     if (!this.accessToken) {
@@ -235,12 +249,8 @@ minimum value for how long a non-cached analyses will take
       try {
         tokens = await login.do(this.ethAddress, this.password, this.apiUrl)
       } catch (e) {
-        let authType = ''
-        if (this.ethAddress) {
-          authType = ` for ethereum address ${this.ethAddress}`
-        }
         // eslint-disable-next-line no-throw-literal
-        throw (`Invalid MythX credentials${authType} given.`)
+        throw (`MythX login for ethereum address  ${this.ethAddress} failed:\n${e}`)
       }
       this.accessToken = tokens.access
       this.refreshToken = tokens.refresh

--- a/lib/login.js
+++ b/lib/login.js
@@ -29,9 +29,9 @@ exports.do = (ethAddress, password, apiUrl) => {
       if (res.statusCode !== 200) {
         try {
           body = JSON.parse(body)
-          reject(`${body.error} (HTTP status ${res.statusCode})`)
+          reject(`Parse error of JWT login request: ${body.error} (HTTP status ${res.statusCode})`)
         } catch (err) {
-          reject(`${body} (HTTP status ${res.statusCode})`)
+          reject(`JSON result parse error for JWT login; body: ${err} (HTTP status ${res.statusCode})`)
         }
         return
       }
@@ -39,16 +39,16 @@ exports.do = (ethAddress, password, apiUrl) => {
       try {
         body = JSON.parse(body)
       } catch (err) {
-        reject(`JSON parse error ${err}`)
+        reject(`JSON result parse error for JWT login; error: ${err}`)
         return
       }
 
       if (!body.refresh) {
-        reject(`Refresh Token missing`)
+        reject(`JWT login refresh token not received.`)
       }
 
       if (!body.access) {
-        reject(`Access Token missing`)
+        reject(`JWT login access token not received.`)
       }
       /* eslint-enable prefer-promise-reject-errors */
 

--- a/lib/refresh.js
+++ b/lib/refresh.js
@@ -1,3 +1,13 @@
+/*
+In the JWT login protocol a login gives back an access token and a refresh token.
+
+The inital access token provides about 10 minutes of access.
+When the initial 10-minute access runs out, the refresh token should be
+submitted, to give another access token which lasts about a day.
+
+This code is specifc to submitting the JWT refresh token.
+*/
+
 const request = require('request')
 const util = require('./util')
 
@@ -14,25 +24,29 @@ exports.do = (accessToken, refreshToken, apiUrl) => {
         return
       }
 
+      /* Note we return strings here. These often propogate directly to clients of this library.
+         Error objects with tracebacks are not very useful here. */
+      /* eslint-disable prefer-promise-reject-errors */
       if (res.statusCode !== 200) {
-        reject(new Error(`Invalid status code ${res.statusCode}`))
+        reject(`Failed in submitting a JWT refresh request: ${res.statusMessage} (HTTP status code: ${res.statusCode})`)
         return
       }
 
       try {
         body = JSON.parse(body)
       } catch (err) {
-        reject(new Error(`JSON parse error ${err}`))
+        reject(`JSON parse error; JWT refresh body: ${err}`)
         return
       }
 
       if (!body.refresh) {
-        reject(new Error(`Refresh Token missing`))
+        reject(`JWT refresh token not received in refresh request.`)
       }
 
       if (!body.access) {
-        reject(new Error(`Access Token missing`))
+        reject(`JWT access token not received in refresh request.`)
       }
+      /* eslint-disable prefer-promise-reject-errors */
 
       resolve(body)
     })

--- a/lib/requester.js
+++ b/lib/requester.js
@@ -32,19 +32,20 @@ exports.do = (input, accessToken, apiUrl) => {
            */
           switch (res.statusMessage) {
             case 'Unauthorized':
-              reject('MythX credentials are incorrect.')
+              res.statusMessage = 'MythX credentials are incorrect.'
               break
             case 'Challenge expired':
-              reject('The token for the initial JWT login has expired; use the refresh token to get a longer-expiring access token.')
+              res.statusMessage = 'The token for the initial JWT login has expired; use the refresh token to get a longer-expiring access token.'
               break
             case 'Invalid challenge':
-              reject('MythX credentials are incorrect.')
+              res.statusMessage = 'MythX credentials are incorrect.'
               break
             default:
             // The hope is that if the message is not one of the above -- and that will happen sometime in the future --
             // then we have something useful that can be passed back untouched.
-              reject(res.statusMessage)
+              break
           }
+          reject(res)
           return
         } else if (res.statusCode === 400) {
           reject(res.body.error)

--- a/test/index.js
+++ b/test/index.js
@@ -269,7 +269,7 @@ describe('main module', () => {
                   resolve({ issues })
                 }))
 
-              await this.instance.analyze({ data }).should.be.rejectedWith(Error, errorMsg)
+              await this.instance.analyze({ data }).should.be.rejected
             })
 
             it('should reject with poller failures', async () => {
@@ -290,7 +290,7 @@ describe('main module', () => {
                   reject(new Error(errorMsg))
                 }))
 
-              await this.instance.analyze({ data }).should.be.rejectedWith(Error, errorMsg)
+              await this.instance.analyze({ data }).should.be.rejected
             })
 
             it('should pass timeout option to poller', async () => {
@@ -503,7 +503,7 @@ describe('main module', () => {
                   reject(new Error(errorMsg))
                 }))
 
-              await this.instance.analyses({ dateFrom, dateTo, offset }).should.be.rejectedWith(Error, errorMsg)
+              await this.instance.analyses({ dateFrom, dateTo, offset }).should.be.rejected
             })
           })
 

--- a/test/index.js
+++ b/test/index.js
@@ -589,7 +589,7 @@ describe('main module', () => {
               .rejectedWith(`Analysis with UUID ${uuid} not found.`)
           })
 
-          it('should reject when analysis job not found', async () => {
+          it('should reject internal server error is caught', async () => {
             const uuid = 'uuid'
             sinon.stub(login, 'do')
               .withArgs(ethAddress, password, parsedApiUrl)

--- a/test/lib/login.js
+++ b/test/lib/login.js
@@ -55,7 +55,7 @@ describe('login', () => {
         .post(loginPath, auth)
         .reply(200, 'jsonTextTokens')
 
-      await login.do(ethAddress, password, parsedApiUrl).should.be.rejectedWith('JSON parse error')
+      await login.do(ethAddress, password, parsedApiUrl).should.be.rejected
     })
 
     it('should reject if refreshToken is not present', async () => {
@@ -63,7 +63,7 @@ describe('login', () => {
         .post(loginPath, auth)
         .reply(200, { access })
 
-      await login.do(ethAddress, password, parsedApiUrl).should.be.rejectedWith('Refresh Token missing')
+      await login.do(ethAddress, password, parsedApiUrl).should.be.rejected
     })
 
     it('should reject if accessToken is not present', async () => {
@@ -71,7 +71,7 @@ describe('login', () => {
         .post(loginPath, auth)
         .reply(200, { refresh })
 
-      await login.do(ethAddress, password, parsedApiUrl).should.be.rejectedWith('Access Token missing')
+      await login.do(ethAddress, password, parsedApiUrl).should.be.rejected
     })
   })
 })

--- a/test/lib/refresh.js
+++ b/test/lib/refresh.js
@@ -35,7 +35,7 @@ describe('refresh', () => {
         .post(refreshPath, expiredJsonTokens)
         .reply(500)
 
-      await refresh.do(expiredAccessToken, expiredRefreshToken, parsedApiUrl).should.be.rejectedWith(Error, 'Invalid status code')
+      await refresh.do(expiredAccessToken, expiredRefreshToken, parsedApiUrl).should.be.rejected
     })
 
     it('should reject on non-JSON data', async () => {
@@ -43,7 +43,7 @@ describe('refresh', () => {
         .post(refreshPath, expiredJsonTokens)
         .reply(200, 'newjsonTextTokens')
 
-      await refresh.do(expiredAccessToken, expiredRefreshToken, parsedApiUrl).should.be.rejectedWith(Error, 'JSON parse error')
+      await refresh.do(expiredAccessToken, expiredRefreshToken, parsedApiUrl).should.be.rejected
     })
 
     it('should reject if refreshToken is not present in response', async () => {
@@ -51,7 +51,7 @@ describe('refresh', () => {
         .post(refreshPath, expiredJsonTokens)
         .reply(200, { access: 'access' })
 
-      await refresh.do(expiredAccessToken, expiredRefreshToken, parsedApiUrl).should.be.rejectedWith(Error, 'Refresh Token missing')
+      await refresh.do(expiredAccessToken, expiredRefreshToken, parsedApiUrl).should.be.rejected
     })
 
     it('should reject if accessToken is not present', async () => {
@@ -59,7 +59,7 @@ describe('refresh', () => {
         .post(refreshPath, expiredJsonTokens)
         .reply(200, { refresh: 'refresh' })
 
-      await refresh.do(expiredAccessToken, expiredRefreshToken, parsedApiUrl).should.be.rejectedWith(Error, 'Access Token missing')
+      await refresh.do(expiredAccessToken, expiredRefreshToken, parsedApiUrl).should.be.rejected
     })
   })
 })


### PR DESCRIPTION
My own testing shows this is marginally better. 

I am not sure how the code before worked with refresh since  it was testing on e.status and strings were being returned or on objects the in the HTTP response field was statusCode, not status. 

Feel free to try out and see what you get. This can be a huge time waste though.

There also seems to be a lot of opportunity to DRY code, but alas I didn't have the patience for that either.