### PR TITLE
analysisPoller now handles refresh properly!

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,8 +72,6 @@ class Client {
     }
 
     await this.login()
-    // console.log(`Access token: ${this.accessToken}`);
-    // console.log(`Refresh token: ${this.refreshToken}`);
 
     let requestResponse
     try {
@@ -228,7 +226,6 @@ class Client {
       result = await simpleRequester.do({ url, accessToken: accessToken, json: true })
     } catch (e) {
       let msg = `Failed in retrieving analysis response, HTTP status code: ${e.status}. UUID: ${uuid}`
-      console.log('EE-status', e.status)
       if (e.status === 404) {
         msg = `Analysis with UUID ${uuid} not found.`
       }

--- a/index.js
+++ b/index.js
@@ -122,7 +122,7 @@ class Client {
 
     let result
     if (requestResponse.status === 'Finished') {
-      result = await analysisPoller.getIssues(requestResponse.uuid, this.accessToken, this.apiUrl)
+      result = await analysisPoller.getIssues(requestResponse.uuid, this)
       if (options.debug) {
         const util = require('util')
         let depth = (options.debug > 1) ? 10 : 2
@@ -131,7 +131,7 @@ class Client {
     } else {
       const initialDelay = Math.max(options.initialDelay || 0, defaultInitialDelay)
       try {
-        result = await analysisPoller.do(requestResponse.uuid, this.accessToken, this.apiUrl, timeout, initialDelay, options.debug)
+        result = await analysisPoller.do(requestResponse.uuid, this, timeout, initialDelay, options.debug)
       } catch (e) {
         /*
           Normally requester passes back strings. However there is a spcial case for
@@ -143,7 +143,7 @@ class Client {
         const tokens = await refresh.do(this.accessToken, this.refreshToken, this.apiUrl)
         this.accessToken = tokens.access
         this.refreshToken = tokens.refresh
-        result = await analysisPoller.do(requestResponse.uuid, this.accessToken, this.apiUrl, timeout,
+        result = await analysisPoller.do(requestResponse.uuid, this, timeout,
           initialDelay, options.debug)
       }
     }

--- a/lib/analysisPoller.js
+++ b/lib/analysisPoller.js
@@ -7,6 +7,7 @@ const fetch = require('omni-fetch')
 const humanizeDuration = require('humanize-duration')
 
 const util = require('./util')
+const refresh = require('./refresh')
 
 /**
  * Throws timeout error.
@@ -25,23 +26,38 @@ function failOnTimeout (status, timeout, uuid) {
   /* eslint-enable no-throw-literal */
 }
 
+async function requestAndHandle (url, uuid, client) {
+  let response = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${client.accessToken}`
+    }
+  })
+  if (response.status === 401) {
+    const tokens = await refresh.do(client.accessToken, client.refreshToken, client.apiUrl)
+    client.accessToken = tokens.access
+    client.refreshToken = tokens.refresh
+    response = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${client.accessToken}`
+      }
+    })
+  }
+  await handleErrors('analysis issues', response, client.accessToken, uuid)
+  return response
+}
+
 /**
  * Gets the array of issues from the API.
  *
  * @param {String} uuid - Analysis UUID.
- * @param {String} accessToken - gives access to use MythX service
- * @param {Object} apiUrl - URL object.
+ * @param {Object} client - armlet client object.
  * @return {Promise} Resolves with API response, or rejects with
- *  an error object.
+ *  a string.
  */
-async function getIssues (uuid, accessToken, apiUrl) {
-  const res = await fetch(`${apiUrl.origin}/v1/analyses/${uuid}/issues`, {
-    headers: {
-      Authorization: `Bearer ${accessToken}`
-    }
-  })
-  await handleErrors('analysis issues', res, accessToken, uuid)
-  return res.json()
+async function getIssues (uuid, client) {
+  const response = await requestAndHandle(`${client.apiUrl.origin}/v1/analyses/${uuid}/issues`,
+    uuid, client)
+  return response.json()
 }
 exports.getIssues = getIssues
 
@@ -80,20 +96,15 @@ async function handleErrors (what, response, accessToken, uuid) {
  * Get status on an analysis request.
  *
  * @param {String} uuid Analysis UUID.
- * @param {String} accessToken gives access to use MythX service
- * @param {Object} apiUrl URL object.
+ * @param {Object} armlet client object.
  * @return {Promise} Resolves with API response payload, or rejects with
- *  an error object.
+ *  a string.
  */
-async function getStatus (uuid, accessToken, apiUrl) {
+async function getStatus (uuid, client) {
   /* Checks analysis status. */
-  let res = await fetch(`${apiUrl.origin}/v1/analyses/${uuid}`, {
-    headers: {
-      Authorization: `Bearer ${accessToken}`
-    }
-  })
-  await handleErrors('analysis status', res, accessToken, uuid)
-  const { status, error } = await res.json()
+  let response = await requestAndHandle(`${client.apiUrl.origin}/v1/analyses/${uuid}`,
+    uuid, client)
+  const { status, error } = await response.json()
   switch (status) {
     case 'Finished': break
     /* eslint-disable no-throw-literal */
@@ -103,13 +114,8 @@ async function getStatus (uuid, accessToken, apiUrl) {
   }
 
   /* Analysis finished successfully: fetches the list of issues. */
-  res = await fetch(`${apiUrl.origin}/v1/analyses/${uuid}/issues`, {
-    headers: {
-      Authorization: `Bearer ${accessToken}`
-    }
-  })
-  await handleErrors('analysis results', res, accessToken)
-  return [status, res.json()]
+  response = await requestAndHandle(`${client.apiUrl.origin}/v1/analyses/${uuid}/issues`, uuid, client)
+  return [status, response.json()]
 }
 
 // No matter how long the timeout, maxPolls is the number of requests
@@ -147,16 +153,14 @@ exports.inverseFn = function (timeout) {
  * waiting until the analysis is finished up to a given polling interval.
  *
  * @param {String} uuid Analysis UUID.
- * @param {String} accessToken Auth token.
- * @param {Object} apiUrl URL object of API base (without /v1, though).
+ * @param {Object} client passed-down client object
  * @param {Number} timeout Operation timeout [ms].
  * @param {Number} initialDelay Operation timeout [ms]. (For initial polling only)
  * @return {Promise} Resolves to the list of issues, or rejects with an error.
  */
 exports.do = async function (
   uuid,
-  accessToken,
-  apiUrl,
+  client,
   timeout,
   initialDelay,
   debug = false
@@ -200,7 +204,8 @@ exports.do = async function (
     if (Date.now() - start >= timeout) {
       failOnTimeout(status, timeout, uuid)
     }
-    [status, statusResponse] = await getStatus(uuid, accessToken, apiUrl)
+
+    [status, statusResponse] = await getStatus(uuid, client)
     if (statusResponse) {
       return statusResponse
     }

--- a/test/index.js
+++ b/test/index.js
@@ -184,7 +184,7 @@ describe('main module', () => {
             login.do.restore()
           })
 
-          it('should login and chain simpleRequester', async () => {
+          it.skip('should login and chain simpleRequester', async () => {
             const uuid = '1234'
             sinon.stub(login, 'do')
               .withArgs(ethAddress, password, parsedApiUrl)
@@ -210,7 +210,7 @@ describe('main module', () => {
             afterEach(() => {
               login.do.restore()
             })
-            it('should login and chain requester and poller', async () => {
+            it.skip('should login and chain requester and poller', async () => {
               sinon.stub(login, 'do')
                 .withArgs(ethAddress, password, parsedApiUrl)
                 .returns(new Promise(resolve => {
@@ -272,7 +272,7 @@ describe('main module', () => {
               await this.instance.analyze({ data }).should.be.rejected
             })
 
-            it('should reject with poller failures', async () => {
+            it.skip('should reject with poller failures', async () => {
               const errorMsg = 'Booom! from poller'
               sinon.stub(login, 'do')
                 .withArgs(ethAddress, password, parsedApiUrl)
@@ -293,7 +293,7 @@ describe('main module', () => {
               await this.instance.analyze({ data }).should.be.rejected
             })
 
-            it('should pass timeout option to poller', async () => {
+            it.skip('should pass timeout option to poller', async () => {
               const timeout = 10
               sinon.stub(login, 'do')
                 .withArgs(ethAddress, password, parsedApiUrl)
@@ -306,7 +306,7 @@ describe('main module', () => {
                   resolve({ uuid, status: 'Finished' })
                 }))
               sinon.stub(poller, 'getIssues')
-                .withArgs(uuid, accessToken, parsedApiUrl)
+                .withArgs({ uuid: uuid, client: this.instance })
                 .returns(issues)
               sinon.stub(poller, 'do')
                 .withArgs(uuid, accessToken, parsedApiUrl, timeout)
@@ -317,7 +317,7 @@ describe('main module', () => {
               poller.getIssues.restore()
             })
 
-            it('should pass default initial delay option to poller', async () => {
+            it.skip('should pass default initial delay option to poller', async () => {
               const timeout = 40000
               sinon.stub(login, 'do')
                 .withArgs(ethAddress, password, parsedApiUrl)
@@ -335,7 +335,7 @@ describe('main module', () => {
               await this.instance.analyze({ data, timeout }).should.eventually.deep.equal({ issues, uuid })
             })
 
-            it('should pass initial delay option to poller', async () => {
+            it.skip('should pass initial delay option to poller', async () => {
               const timeout = 40000
               const initialDelay = 50000
               sinon.stub(login, 'do')
@@ -358,7 +358,7 @@ describe('main module', () => {
           })
 
           describe('when the client is already logged in', () => {
-            it('should not call login again', async () => {
+            it.skip('should not call login again', async () => {
               this.instance.accessToken = accessToken
 
               sinon.stub(requester, 'do')
@@ -392,7 +392,7 @@ describe('main module', () => {
             poller.do.restore()
           })
 
-          it('should refresh expired tokens when requester fails', async () => {
+          it.skip('should refresh expired tokens when requester fails', async () => {
             const requesterStub = sinon.stub(requester, 'do')
             requesterStub.withArgs({ data }, accessToken, parsedApiUrl)
               .returns(new Promise((resolve, reject) => {
@@ -418,7 +418,7 @@ describe('main module', () => {
             await this.instance.analyze({ data }).should.eventually.deep.equal({ issues, uuid })
           })
 
-          it('should refresh expired tokens when poller fails', async () => {
+          it.skip('should refresh expired tokens when poller fails', async () => {
             const pollerStub = sinon.stub(poller, 'do')
             pollerStub.withArgs(uuid, accessToken, parsedApiUrl)
               .returns(new Promise((resolve, reject) => {
@@ -512,11 +512,11 @@ describe('main module', () => {
               simpleRequester.do.restore()
             })
 
-            it('should not call login again', async () => {
+            it.skip('should not call login again', async () => {
               this.instance.accessToken = accessToken
 
               sinon.stub(simpleRequester, 'do')
-                .withArgs({ url, accessToken, json: true })
+                .withArgs({ url, client: this.instance, json: true })
                 .returns(new Promise(resolve => {
                   resolve(analyses)
                 }))
@@ -560,7 +560,7 @@ describe('main module', () => {
           })
         })
 
-        describe('getStatusOrIssues', () => {
+        describe.skip('getStatusOrIssues', () => {
           afterEach(() => {
             simpleRequester.do.restore()
             login.do.restore()
@@ -572,7 +572,7 @@ describe('main module', () => {
               .withArgs(ethAddress, password, parsedApiUrl)
               .resolves({ access: accessToken, refresh: refreshToken })
             sinon.stub(simpleRequester, 'do')
-              .withArgs({ url: apiUrl, accessToken, json: true })
+              .withArgs({ url: apiUrl, client: this.instance, json: true })
               .resolves([])
             await this.instance.getStatusOrIssues(uuid, apiUrl).should.eventually.deep.equal([])
           })

--- a/test/index.js
+++ b/test/index.js
@@ -184,7 +184,7 @@ describe('main module', () => {
             login.do.restore()
           })
 
-          it.skip('should login and chain simpleRequester', async () => {
+          it('should login and chain simpleRequester', async () => {
             const uuid = '1234'
             sinon.stub(login, 'do')
               .withArgs(ethAddress, password, parsedApiUrl)
@@ -210,7 +210,7 @@ describe('main module', () => {
             afterEach(() => {
               login.do.restore()
             })
-            it.skip('should login and chain requester and poller', async () => {
+            it('should login and chain requester and poller', async () => {
               sinon.stub(login, 'do')
                 .withArgs(ethAddress, password, parsedApiUrl)
                 .returns(new Promise(resolve => {
@@ -222,7 +222,7 @@ describe('main module', () => {
                   resolve({ uuid })
                 }))
               sinon.stub(poller, 'do')
-                .withArgs(uuid, accessToken, parsedApiUrl)
+                .withArgs(uuid, this.instance)
                 .returns(new Promise(resolve => {
                   resolve(issues)
                 }))
@@ -272,7 +272,7 @@ describe('main module', () => {
               await this.instance.analyze({ data }).should.be.rejected
             })
 
-            it.skip('should reject with poller failures', async () => {
+            it('should reject with poller failures', async () => {
               const errorMsg = 'Booom! from poller'
               sinon.stub(login, 'do')
                 .withArgs(ethAddress, password, parsedApiUrl)
@@ -285,7 +285,7 @@ describe('main module', () => {
                   resolve({ uuid })
                 }))
               sinon.stub(poller, 'do')
-                .withArgs(uuid, accessToken, parsedApiUrl)
+                .withArgs(uuid, this.instance)
                 .returns(new Promise((resolve, reject) => {
                   reject(new Error(errorMsg))
                 }))
@@ -293,7 +293,7 @@ describe('main module', () => {
               await this.instance.analyze({ data }).should.be.rejected
             })
 
-            it.skip('should pass timeout option to poller', async () => {
+            it('should pass timeout option to poller', async () => {
               const timeout = 10
               sinon.stub(login, 'do')
                 .withArgs(ethAddress, password, parsedApiUrl)
@@ -306,10 +306,10 @@ describe('main module', () => {
                   resolve({ uuid, status: 'Finished' })
                 }))
               sinon.stub(poller, 'getIssues')
-                .withArgs({ uuid: uuid, client: this.instance })
-                .returns(issues)
+                .withArgs(uuid, this.instance)
+                .resolves(issues)
               sinon.stub(poller, 'do')
-                .withArgs(uuid, accessToken, parsedApiUrl, timeout)
+                .withArgs(uuid, this.instance, timeout)
                 .returns(new Promise(resolve => {
                   resolve(issues)
                 }))
@@ -317,7 +317,7 @@ describe('main module', () => {
               poller.getIssues.restore()
             })
 
-            it.skip('should pass default initial delay option to poller', async () => {
+            it('should pass default initial delay option to poller', async () => {
               const timeout = 40000
               sinon.stub(login, 'do')
                 .withArgs(ethAddress, password, parsedApiUrl)
@@ -330,12 +330,12 @@ describe('main module', () => {
                   resolve({ uuid })
                 }))
               sinon.stub(poller, 'do')
-                .withArgs(uuid, accessToken, parsedApiUrl, timeout, armlet.defaultInitialDelay, undefined)
+                .withArgs(uuid, this.instance, timeout, armlet.defaultInitialDelay, undefined)
                 .resolves(issues)
               await this.instance.analyze({ data, timeout }).should.eventually.deep.equal({ issues, uuid })
             })
 
-            it.skip('should pass initial delay option to poller', async () => {
+            it('should pass initial delay option to poller', async () => {
               const timeout = 40000
               const initialDelay = 50000
               sinon.stub(login, 'do')
@@ -349,7 +349,7 @@ describe('main module', () => {
                   resolve({ uuid })
                 }))
               sinon.stub(poller, 'do')
-                .withArgs(uuid, accessToken, parsedApiUrl, timeout, initialDelay, undefined)
+                .withArgs(uuid, this.instance, timeout, initialDelay, undefined)
                 .returns(new Promise(resolve => {
                   resolve(issues)
                 }))
@@ -358,7 +358,7 @@ describe('main module', () => {
           })
 
           describe('when the client is already logged in', () => {
-            it.skip('should not call login again', async () => {
+            it('should not call login again', async () => {
               this.instance.accessToken = accessToken
 
               sinon.stub(requester, 'do')
@@ -367,7 +367,7 @@ describe('main module', () => {
                   resolve({ uuid })
                 }))
               sinon.stub(poller, 'do')
-                .withArgs(uuid, accessToken, parsedApiUrl)
+                .withArgs(uuid, this.instance)
                 .returns(new Promise(resolve => {
                   resolve(issues)
                 }))
@@ -392,7 +392,7 @@ describe('main module', () => {
             poller.do.restore()
           })
 
-          it.skip('should refresh expired tokens when requester fails', async () => {
+          it('should refresh expired tokens when requester fails', async () => {
             const requesterStub = sinon.stub(requester, 'do')
             requesterStub.withArgs({ data }, accessToken, parsedApiUrl)
               .returns(new Promise((resolve, reject) => {
@@ -410,7 +410,7 @@ describe('main module', () => {
               }))
 
             sinon.stub(poller, 'do')
-              .withArgs(uuid, newAccessToken, parsedApiUrl)
+              .withArgs(uuid, this.instance)
               .returns(new Promise(resolve => {
                 resolve(issues)
               }))
@@ -418,13 +418,14 @@ describe('main module', () => {
             await this.instance.analyze({ data }).should.eventually.deep.equal({ issues, uuid })
           })
 
-          it.skip('should refresh expired tokens when poller fails', async () => {
-            const pollerStub = sinon.stub(poller, 'do')
-            pollerStub.withArgs(uuid, accessToken, parsedApiUrl)
+          it('should refresh expired tokens when poller fails', async () => {
+            sinon.stub(poller, 'do')
+              .withArgs(uuid, this.instance)
+              .onFirstCall()
               .returns(new Promise((resolve, reject) => {
                 reject(HttpErrors.Unauthorized())
               }))
-            pollerStub.withArgs(uuid, newAccessToken, parsedApiUrl)
+              .onSecondCall()
               .returns(new Promise(resolve => {
                 resolve(issues)
               }))
@@ -512,11 +513,11 @@ describe('main module', () => {
               simpleRequester.do.restore()
             })
 
-            it.skip('should not call login again', async () => {
+            it('should not call login again', async () => {
               this.instance.accessToken = accessToken
 
               sinon.stub(simpleRequester, 'do')
-                .withArgs({ url, client: this.instance, json: true })
+                .withArgs({ url, accessToken, json: true })
                 .returns(new Promise(resolve => {
                   resolve(analyses)
                 }))
@@ -560,7 +561,7 @@ describe('main module', () => {
           })
         })
 
-        describe.skip('getStatusOrIssues', () => {
+        describe('getStatusOrIssues', () => {
           afterEach(() => {
             simpleRequester.do.restore()
             login.do.restore()
@@ -572,7 +573,7 @@ describe('main module', () => {
               .withArgs(ethAddress, password, parsedApiUrl)
               .resolves({ access: accessToken, refresh: refreshToken })
             sinon.stub(simpleRequester, 'do')
-              .withArgs({ url: apiUrl, client: this.instance, json: true })
+              .withArgs({ url: apiUrl, accessToken, json: true })
               .resolves([])
             await this.instance.getStatusOrIssues(uuid, apiUrl).should.eventually.deep.equal([])
           })

--- a/test/lib/analysisPoller.js
+++ b/test/lib/analysisPoller.js
@@ -35,7 +35,7 @@ describe('analysisPoller', () => {
       sinon.stub(util, 'timer')
     })
 
-    it('should poll issues with empty results', async () => {
+    it.skip('should poll issues with empty results', async () => {
       const emptyResult = []
 
       nock(defaultApiUrl.href, {
@@ -68,7 +68,7 @@ describe('analysisPoller', () => {
       await poller.do(uuid, validApiKey, defaultApiUrl, 10000, 5000).should.eventually.deep.equal(emptyResult)
     })
 
-    it('should poll issues with non-empty results', async () => {
+    it.skip('should poll issues with non-empty results', async () => {
       nock(defaultApiUrl.href, {
         reqheaders: {
           authorization: `Bearer ${validApiKey}`
@@ -99,7 +99,7 @@ describe('analysisPoller', () => {
       await poller.do(uuid, validApiKey, defaultApiUrl, 10000, 5000).should.eventually.deep.equal(expectedIssues)
     })
 
-    it('should be able to query http API', async () => {
+    it.skip('should be able to query http API', async () => {
       nock(httpApiUrl.href, {
         reqheaders: {
           authorization: `Bearer ${validApiKey}`
@@ -127,7 +127,9 @@ describe('analysisPoller', () => {
         .get(issuesUrl)
         .reply(200, expectedIssues)
 
-      await poller.do(uuid, validApiKey, httpApiUrl, 10000, 5000).should.eventually.deep.equal(expectedIssues)
+      // FIXME: validApiKey shodl be an armlet client
+      // Also DRY code
+      await poller.do(uuid, validApiKey, 10000, 5000).should.eventually.deep.equal(expectedIssues)
     })
 
     it('should reject on server error', async () => {
@@ -139,7 +141,8 @@ describe('analysisPoller', () => {
         .get(statusUrl)
         .reply(500)
 
-      await poller.do(uuid, validApiKey, defaultApiUrl, 10000, 5000).should.be.rejected
+      // FIXME: validApiKey should be an armlet client
+      await poller.do(uuid, validApiKey, 10000, 5000).should.be.rejected
     })
 
     it('should reject on non-JSON data', async () => {
@@ -170,7 +173,8 @@ describe('analysisPoller', () => {
         .get(issuesUrl)
         .reply(200, 'non-json-data')
 
-      await poller.do(uuid, validApiKey, defaultApiUrl, 10000, 5000).should.be.rejected
+      // FIXME: validApiKey should be an armlet client
+      await poller.do(uuid, validApiKey, 10000, 5000).should.be.rejected
     })
 
     it('should reject after a timeout', async () => {
@@ -185,11 +189,13 @@ describe('analysisPoller', () => {
         .reply(200, {
           status: 'In progress'
         })
-      await poller.do(uuid, validApiKey, defaultApiUrl, timeout, 5000).should.be
+
+      // FIXME: validApiKey should be an armlet client
+      await poller.do(uuid, validApiKey, timeout, 5000).should.be
         .rejected
     })
 
-    it('should wait for initialDelay', async () => {
+    it.skip('should wait for initialDelay', async () => {
       const emptyResult = []
 
       nock(defaultApiUrl.href, {
@@ -225,7 +231,7 @@ describe('analysisPoller', () => {
       delay.should.be.equal(initialDelay)
     })
 
-    it('should wait for polling longer each time', async () => {
+    it.skip('should wait for polling longer each time', async () => {
       const emptyResult = []
 
       nock(defaultApiUrl.href, {
@@ -275,7 +281,8 @@ describe('analysisPoller', () => {
         .reply(200, {
           status: 'In progress'
         })
-      await poller.do(uuid, validApiKey, defaultApiUrl).should.be.rejected
+      // FIXME: validApiKey shodl be an armlet client
+      await poller.do(uuid, validApiKey).should.be.rejected
     })
   })
 })

--- a/test/lib/analysisPoller.js
+++ b/test/lib/analysisPoller.js
@@ -10,8 +10,7 @@ const util = require('../../lib/util')
 
 describe('analysisPoller', () => {
   describe('#do', () => {
-    const defaultApiUrl = new url.URL('https://api.mythx.io')
-    const httpApiUrl = new url.URL('http://localhost:3100')
+    const apiUrl = new url.URL('https://api.mythx.io')
     const validApiKey = 'valid-api-key'
     const uuid = 'my-uuid'
     const statusUrl = `/v1/analyses/${uuid}`
@@ -27,6 +26,12 @@ describe('analysisPoller', () => {
       }
     ]
 
+    const client = {
+      accessToken: validApiKey,
+      refreshToken: 'refreshToken',
+      apiUrl: apiUrl
+    }
+
     afterEach(() => {
       util.timer.restore()
     })
@@ -35,10 +40,9 @@ describe('analysisPoller', () => {
       sinon.stub(util, 'timer')
     })
 
-    it.skip('should poll issues with empty results', async () => {
+    it('should poll issues with empty results', async () => {
       const emptyResult = []
-
-      nock(defaultApiUrl.href, {
+      nock(apiUrl.href, {
         reqheaders: {
           authorization: `Bearer ${validApiKey}`
         }
@@ -48,7 +52,7 @@ describe('analysisPoller', () => {
         .reply(200, {
           status: 'In progress'
         })
-      nock(defaultApiUrl.href, {
+      nock(apiUrl.href, {
         reqheaders: {
           authorization: `Bearer ${validApiKey}`
         }
@@ -57,7 +61,7 @@ describe('analysisPoller', () => {
         .reply(200, {
           status: 'Finished'
         })
-      nock(defaultApiUrl.href, {
+      nock(apiUrl.href, {
         reqheaders: {
           authorization: `Bearer ${validApiKey}`
         }
@@ -65,11 +69,11 @@ describe('analysisPoller', () => {
         .get(issuesUrl)
         .reply(200, emptyResult)
 
-      await poller.do(uuid, validApiKey, defaultApiUrl, 10000, 5000).should.eventually.deep.equal(emptyResult)
+      await poller.do(uuid, client, 10000, 5000).should.eventually.deep.equal(emptyResult)
     })
 
-    it.skip('should poll issues with non-empty results', async () => {
-      nock(defaultApiUrl.href, {
+    it('should poll issues with non-empty results', async () => {
+      nock(apiUrl.href, {
         reqheaders: {
           authorization: `Bearer ${validApiKey}`
         }
@@ -79,7 +83,7 @@ describe('analysisPoller', () => {
         .reply(200, {
           status: 'In progress'
         })
-      nock(defaultApiUrl.href, {
+      nock(apiUrl.href, {
         reqheaders: {
           authorization: `Bearer ${validApiKey}`
         }
@@ -88,7 +92,7 @@ describe('analysisPoller', () => {
         .reply(200, {
           status: 'Finished'
         })
-      nock(defaultApiUrl.href, {
+      nock(apiUrl.href, {
         reqheaders: {
           authorization: `Bearer ${validApiKey}`
         }
@@ -96,11 +100,11 @@ describe('analysisPoller', () => {
         .get(issuesUrl)
         .reply(200, expectedIssues)
 
-      await poller.do(uuid, validApiKey, defaultApiUrl, 10000, 5000).should.eventually.deep.equal(expectedIssues)
+      await poller.do(uuid, client, 10000, 5000).should.eventually.deep.equal(expectedIssues)
     })
 
-    it.skip('should be able to query http API', async () => {
-      nock(httpApiUrl.href, {
+    it('should be able to query http API', async () => {
+      nock(apiUrl.href, {
         reqheaders: {
           authorization: `Bearer ${validApiKey}`
         }
@@ -110,7 +114,7 @@ describe('analysisPoller', () => {
         .reply(200, {
           status: 'In progress'
         })
-      nock(httpApiUrl.href, {
+      nock(apiUrl.href, {
         reqheaders: {
           authorization: `Bearer ${validApiKey}`
         }
@@ -119,7 +123,7 @@ describe('analysisPoller', () => {
         .reply(200, {
           status: 'Finished'
         })
-      nock(httpApiUrl.href, {
+      nock(apiUrl.href, {
         reqheaders: {
           authorization: `Bearer ${validApiKey}`
         }
@@ -127,13 +131,11 @@ describe('analysisPoller', () => {
         .get(issuesUrl)
         .reply(200, expectedIssues)
 
-      // FIXME: validApiKey shodl be an armlet client
-      // Also DRY code
-      await poller.do(uuid, validApiKey, 10000, 5000).should.eventually.deep.equal(expectedIssues)
+      await poller.do(uuid, client, 10000, 5000).should.eventually.deep.equal(expectedIssues)
     })
 
     it('should reject on server error', async () => {
-      nock(defaultApiUrl.href, {
+      nock(apiUrl.href, {
         reqheaders: {
           authorization: `Bearer ${validApiKey}`
         }
@@ -141,12 +143,11 @@ describe('analysisPoller', () => {
         .get(statusUrl)
         .reply(500)
 
-      // FIXME: validApiKey should be an armlet client
-      await poller.do(uuid, validApiKey, 10000, 5000).should.be.rejected
+      await poller.do(uuid, client, 10000, 5000).should.be.rejected
     })
 
     it('should reject on non-JSON data', async () => {
-      nock(defaultApiUrl.href, {
+      nock(apiUrl.href, {
         reqheaders: {
           authorization: `Bearer ${validApiKey}`
         }
@@ -156,7 +157,7 @@ describe('analysisPoller', () => {
         .reply(200, {
           status: 'In progress'
         })
-      nock(defaultApiUrl.href, {
+      nock(apiUrl.href, {
         reqheaders: {
           authorization: `Bearer ${validApiKey}`
         }
@@ -165,7 +166,7 @@ describe('analysisPoller', () => {
         .reply(200, {
           status: 'Finished'
         })
-      nock(defaultApiUrl.href, {
+      nock(apiUrl.href, {
         reqheaders: {
           authorization: `Bearer ${validApiKey}`
         }
@@ -173,13 +174,12 @@ describe('analysisPoller', () => {
         .get(issuesUrl)
         .reply(200, 'non-json-data')
 
-      // FIXME: validApiKey should be an armlet client
-      await poller.do(uuid, validApiKey, 10000, 5000).should.be.rejected
+      await poller.do(uuid, client, 10000, 5000).should.be.rejected
     })
 
     it('should reject after a timeout', async () => {
       const timeout = 15
-      nock(defaultApiUrl.href, {
+      nock(apiUrl.href, {
         reqheaders: {
           authorization: `Bearer ${validApiKey}`
         }
@@ -190,15 +190,13 @@ describe('analysisPoller', () => {
           status: 'In progress'
         })
 
-      // FIXME: validApiKey should be an armlet client
-      await poller.do(uuid, validApiKey, timeout, 5000).should.be
-        .rejected
+      await poller.do(uuid, client, timeout, 5000).should.be.rejected
     })
 
-    it.skip('should wait for initialDelay', async () => {
+    it('should wait for initialDelay', async () => {
       const emptyResult = []
 
-      nock(defaultApiUrl.href, {
+      nock(apiUrl.href, {
         reqheaders: {
           authorization: `Bearer ${validApiKey}`
         }
@@ -208,7 +206,7 @@ describe('analysisPoller', () => {
         .reply(200, {
           status: 'In progress'
         })
-      nock(defaultApiUrl.href, {
+      nock(apiUrl.href, {
         reqheaders: {
           authorization: `Bearer ${validApiKey}`
         }
@@ -217,7 +215,7 @@ describe('analysisPoller', () => {
         .reply(200, {
           status: 'Finished'
         })
-      nock(defaultApiUrl.href, {
+      nock(apiUrl.href, {
         reqheaders: {
           authorization: `Bearer ${validApiKey}`
         }
@@ -226,15 +224,15 @@ describe('analysisPoller', () => {
         .reply(200, emptyResult)
 
       const initialDelay = 5000
-      await poller.do(uuid, validApiKey, defaultApiUrl, 10000, 5000).should.eventually.deep.equal(emptyResult)
+      await poller.do(uuid, client, 10000, 5000).should.eventually.deep.equal(emptyResult)
       const delay = util.timer.getCall(0).args[0]
       delay.should.be.equal(initialDelay)
     })
 
-    it.skip('should wait for polling longer each time', async () => {
+    it('should wait for polling longer each time', async () => {
       const emptyResult = []
 
-      nock(defaultApiUrl.href, {
+      nock(apiUrl.href, {
         reqheaders: {
           authorization: `Bearer ${validApiKey}`
         }
@@ -244,7 +242,7 @@ describe('analysisPoller', () => {
         .reply(200, {
           status: 'In progress'
         })
-      nock(defaultApiUrl.href, {
+      nock(apiUrl.href, {
         reqheaders: {
           authorization: `Bearer ${validApiKey}`
         }
@@ -253,7 +251,7 @@ describe('analysisPoller', () => {
         .reply(200, {
           status: 'Finished'
         })
-      nock(defaultApiUrl.href, {
+      nock(apiUrl.href, {
         reqheaders: {
           authorization: `Bearer ${validApiKey}`
         }
@@ -262,7 +260,7 @@ describe('analysisPoller', () => {
         .reply(200, emptyResult)
 
       let lastDelay = 0
-      await poller.do(uuid, validApiKey, defaultApiUrl, 10000, 5000).should.eventually.deep.equal(emptyResult)
+      await poller.do(uuid, client, 10000, 5000).should.eventually.deep.equal(emptyResult)
       for (const i of [1, 2, 3]) {
         const nextDelay = util.timer.getCall(i).args[0]
         nextDelay.should.be.above(lastDelay)
@@ -271,7 +269,7 @@ describe('analysisPoller', () => {
     })
 
     it('should reject after maximum polling reached', async () => {
-      nock(defaultApiUrl.href, {
+      nock(apiUrl.href, {
         reqheaders: {
           authorization: `Bearer ${validApiKey}`
         }


### PR DESCRIPTION
I think handling refresh here has been broken from the very beginning, even
in the times it was called "poller.js".

We never noticed this before, because another misfeature caused many
unecessary logins to occur. Therefore we never really ran into
running refresh. Since that was fixed, this latent bug surfaced.