### PR TITLE
bug fix: fix wrong polling time

### DIFF
--- a/lib/analysisPoller.js
+++ b/lib/analysisPoller.js
@@ -197,7 +197,7 @@ exports.do = async function (
         console.log(`polling interval: ${humanizeDuration(pollStep)}, previous status: ${status}`)
       }
 
-      await util.timer(Math.min(pollStep, start + remainTime - Date.now()))
+      await util.timer(Math.min(pollStep, start + timeout - Date.now()))
     }
 
     let statusResponse


### PR DESCRIPTION
It can set wrong polling time after first polling.

e.g.
   WalletLibrary |**************************************************************************************              | 86% || Elapsed: 263.3s ✗ timeout

Default timeout is 300s, but timeout occurs even for less than 300 seconds.
We should use not remainTime but timeout to determine polling time.