### PR TITLE
Bug Fix on simpleRequester error handling

### DIFF
--- a/lib/simpleRequester.js
+++ b/lib/simpleRequester.js
@@ -43,10 +43,10 @@ exports.do = options => {
         try {
           body = JSON.parse(body)
         } catch (err) {
-          reject(HttpErrors(res.statusCode, 'Invalid status code, expected 200'))
+          reject(new Error(`JSON parse error ${err}`))
           return
         }
-        reject(body)
+        reject(HttpErrors(res.statusCode, 'Invalid status code, expected 200'))
         return
       }
       if (options.json) {


### PR DESCRIPTION
I found bug regarding simpleRequester error handling.
If statusCode is not 200, it should throw not `JSON parse error` but `Invalid status code`.