### PR TITLE
Bug Fix: set token after login on getStatusOrIssues

### DIFF
--- a/index.js
+++ b/index.js
@@ -216,14 +216,11 @@ class Client {
   }
 
   async getStatusOrIssues (uuid, url) {
-    let accessToken = this.accessToken
-    if (!accessToken) {
-      const tokens = await login.do(this.ethAddress, this.password, this.apiUrl)
-      accessToken = tokens.access
-    }
+    await this.login()
+
     let result
     try {
-      result = await simpleRequester.do({ url, accessToken: accessToken, json: true })
+      result = await simpleRequester.do({ url, accessToken: this.accessToken, json: true })
     } catch (e) {
       let msg = `Failed in retrieving analysis response, HTTP status code: ${e.status}. UUID: ${uuid}`
       if (e.status === 404) {


### PR DESCRIPTION
armlet sends login request to MythX API per calling getStatusOrIssues if accessToken is not set.
I think clients using armlet send getIssues after getStatus.
In this usecase, armlet send login request two times since it never sets accessToken of instance.

### As-Is: getStatus -> getIssues (login requests two times)
![AS-IS](https://user-images.githubusercontent.com/17696068/54662305-f0a6a300-4b20-11e9-8d56-964e2c3e552c.jpg)

### To-Be: getStatus -> getIssues (login one time)
![To-Be](https://user-images.githubusercontent.com/17696068/54662334-04520980-4b21-11e9-8eec-a4d423b8da6e.jpg)
