### PR TITLE
Handle cases where data is undefined in requester

### DIFF
--- a/lib/requester.js
+++ b/lib/requester.js
@@ -66,7 +66,9 @@ exports.do = (input, accessToken, apiUrl) => {
             // then we have something useful that can be passed back untouched.
               reject(res.statusMessage)
           }
-        } else if (!data || !data.details) {
+        }
+
+        if (!data || !data.details) {
           reject(errMsg)
           return
         }


### PR DESCRIPTION
To prevent the following error, which I encountered via `truffle-security`:
```
.../node_modules/armlet/lib/requester.js:73
        const msgs = data.details.reduce((acc, detail) => {
                          ^
TypeError: Cannot read property 'details' of undefined
```